### PR TITLE
Trim output of git rev-parse

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -3746,7 +3746,7 @@ ${gitStatus}`);
   await (0, import_exec.exec)("git", ["diff", "--cached"]);
   const commitMessage = import_core.default.getInput("commit-message") || `Release v${version}`;
   await (0, import_exec.exec)("git", ["commit", "--message", commitMessage]);
-  const commitHash = await execOutput("git", ["rev-parse", "HEAD"]);
+  const commitHash = (await execOutput("git", ["rev-parse", "HEAD"])).trim();
   import_core.default.setOutput("sha", commitHash);
   if (import_core.default.getBooleanInput("push")) {
     await (0, import_exec.exec)("git", ["push", "--set-upstream", "origin", "HEAD"]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ async function main(): Promise<void> {
   await exec("git", ["commit", "--message", commitMessage]);
 
   // save commit hash
-  const commitHash = await execOutput("git", ["rev-parse", "HEAD"]);
+  const commitHash = (await execOutput("git", ["rev-parse", "HEAD"])).trim();
   core.setOutput("sha", commitHash);
 
   // push to origin if requested


### PR DESCRIPTION
The output of rev-parse contains a trailing newline:

```
> child_process.execSync("git rev-parse HEAD").toString()
'efbe05b189734da66b4c6c036dc56541e6ee2403\n'
```

This needs to be trimmed before setting the `sha` output variable or it breaks things downstream.