### PR TITLE
Update build step to target node16

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://foxglove.dev/"
   },
   "scripts": {
-    "build": "esbuild --platform=node --target=node12 --bundle --outfile=dist/index.js src/index.ts",
+    "build": "esbuild --platform=node --target=node16 --bundle --outfile=dist/index.js src/index.ts",
     "watch": "yarn run build --watch",
     "clean": "rimraf dist *.tsbuildinfo",
     "lint": "eslint --report-unused-disable-directives --fix .",


### PR DESCRIPTION
The action is configured to run using node16 so the build step can also target node16.

---
I ran `yarn build` but this did not change the dist/index.js file so I guess the target makes no difference between these two versions.